### PR TITLE
Add V2 receive API

### DIFF
--- a/docs/receive.md
+++ b/docs/receive.md
@@ -1,4 +1,4 @@
-##Receive functionality
+##Receive V1 functionality (deprecated)
 
 ####`receive`
 Call the 'api/receive' endpoint and create a forwarding address. Returns a `ReceiveResponse` object.
@@ -15,5 +15,43 @@ Usage:
 require 'blockchain'
 
 resp = Blockchain::receive('1hNapz1CuH4DhnV1DFHH7hafwDE8FJRheA', 'http://your.url.com')
+
+```
+
+
+##Receive V2 functionality
+
+####`receive`
+Call the 'v2/receive' endpoint and create a new address. Returns a `V2::ReceiveResponse` object.
+
+Params:
+```
+xpub : str
+callback : str
+api_key : str
+```
+
+Usage:
+```ruby
+require 'blockchain'
+
+resp = Blockchain::V2::receive('xpub1hNapz1CuH4DhnV1DFHH7hafwDE8FJRheA', 'http://your.url.com', 'yourApiKey')
+
+```
+
+####`callback_log`
+Call the 'v2/receive/callback_log' endpoint. Returns an array of `LogEntry` objects.
+
+Params:
+```
+callback : str
+api_key : str
+```
+
+Usage:
+```ruby
+require 'blockchain'
+
+resp = Blockchain::callback_log('1hNapz1CuH4DhnV1DFHH7hafwDE8FJRheA', 'http://your.url.com')
 
 ```

--- a/lib/blockchain.rb
+++ b/lib/blockchain.rb
@@ -8,5 +8,6 @@ require "blockchain/statistics"
 require "blockchain/wallet"
 
 module Blockchain
-
+	module V2
+	end
 end

--- a/lib/blockchain/receive.rb
+++ b/lib/blockchain/receive.rb
@@ -61,7 +61,6 @@ module Blockchain
 			params = { 'xpub' => xpub, 'callback' => callback, 'key' => api_key }
 			resp = Blockchain::call_api('v2/receive', method: 'get', data: params, base_url: 'https://api.blockchain.info/')
 			json_resp = JSON.parse(resp)
-			p json_resp
 			receive_response = ReceiveResponse.new(json_resp['address'],
 													json_resp['index'],
 													json_resp['callback'])

--- a/lib/blockchain/receive.rb
+++ b/lib/blockchain/receive.rb
@@ -1,4 +1,5 @@
 require 'json'
+
 require_relative 'util'
 
 module Blockchain
@@ -8,14 +9,14 @@ module Blockchain
 		attr_reader :destination
 		attr_reader :input_address
 		attr_reader :callback_url
-		
+
 		def initialize(fee_percent, dest, input, callback)
 			@fee_percent = fee_percent
 			@destination = dest
 			@input_address = input
 			@callback_url = callback
 		end
-	end	
+	end
 
 	def self.receive(dest_addr, callback, api_code = nil)
 		params = { 'method' => 'create', 'address' => dest_addr, 'callback' => callback }
@@ -28,5 +29,59 @@ module Blockchain
 												json_resp['callback_url'])
 		return receive_response
 	end
+
+	module V2
+		class ReceiveResponse
+			attr_reader :address
+			attr_reader :index
+			attr_reader :callback_url
+
+			def initialize(address, index, callback)
+				@address = address
+				@index = index
+				@callback_url = callback
+			end
+		end
+
+		class LogEntry
+			attr_reader :callback_url
+			attr_reader :called_at
+			attr_reader :raw_response
+			attr_reader :response_code
+
+			def initialize(callback_url, called_at, raw_response, response_code)
+				@callback_url = callback_url
+				@called_at = called_at
+				@raw_response = raw_response
+				@response_code = response_code
+			end
+		end
+
+		def self.receive(xpub, callback, api_key)
+			params = { 'xpub' => xpub, 'callback' => callback, 'key' => api_key }
+			resp = Blockchain::call_api('v2/receive', method: 'get', data: params, base_url: 'https://api.blockchain.info/')
+			json_resp = JSON.parse(resp)
+			p json_resp
+			receive_response = ReceiveResponse.new(json_resp['address'],
+													json_resp['index'],
+													json_resp['callback'])
+			receive_response
+		end
+
+		def self.callback_log(callback, api_key = nil)
+			params = {'callback' => callback }
+			params['key'] = api_key unless api_key.nil?
+			resp = Blockchain::call_api('v2/receive/callback_log', method: 'get', data: params, base_url: 'https://api.blockchain.info/')
+			json_resp = JSON.parse(resp)
+			receive_response = json_resp.map do |entry|
+				LogEntry.new(entry['callback_url'],
+							entry['called_at'],
+							entry['raw_response'],
+							entry['response_code'])
+			end
+			receive_response
+		end
+	end
+
 
 end

--- a/lib/blockchain/util.rb
+++ b/lib/blockchain/util.rb
@@ -8,8 +8,9 @@ module Blockchain
 	BASE_URL = "https://blockchain.info/"
 	TIMEOUT_SECONDS = 10
 	
-	def self.call_api(resource, method: 'get', data: nil)
-		url = URI.parse(BASE_URL + resource)
+	def self.call_api(resource, method: 'get', data: nil, base_url: nil)
+		base_url ||= BASE_URL
+		url = URI.parse(base_url + resource)
 		http = Net::HTTP.new(url.host, url.port)
 		http.use_ssl = true
 		http.read_timeout = TIMEOUT_SECONDS

--- a/lib/blockchain/version.rb
+++ b/lib/blockchain/version.rb
@@ -1,3 +1,3 @@
 module Blockchain
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
V2 receive is called from `Blockchain::V2::receive`.

I’d have preferred to encapsulate the V1 functionality under a `V1`
module across the board too, but `include` doesn’t particularly like
`self.method`, and I couldn’t quite figure out how to cleanly achieve
this while preserving the `Blockchain::method` call convention (as
opposed to the `Blockchain.method` style)