### PR TITLE
Clean up and fix V2::Receive API

### DIFF
--- a/lib/blockchain/receive.rb
+++ b/lib/blockchain/receive.rb
@@ -3,98 +3,87 @@ require 'json'
 require_relative 'client'
 
 module Blockchain
+  module V2
+    class Receive
+      attr_reader :client
 
-	class ReceiveResponse
-		attr_reader :fee_percent
-		attr_reader :destination
-		attr_reader :input_address
-		attr_reader :callback_url
+      def initialize(base_url = nil)
+        base_url = base_url.nil? ? 'https://api.blockchain.info/v2/' : base_url
+        @client = Client.new(base_url)
+      end
 
-		def initialize(fee_percent, dest, input, callback)
-			@fee_percent = fee_percent
-			@destination = dest
-			@input_address = input
-			@callback_url = callback
-		end
-	end
+      def proxy(method_name, *args)
+        warn "[DEPRECATED] avoid use of static methods, use an instance of Receive class instead."
+        send(method_name, *args)
+      end
 
-	module V2
+      def receive(xpub, callback, api_key, gap_limit = nil)
+        params = { 'xpub' => xpub, 'callback' => callback, 'key' => api_key }
+        params['gap_limit'] = gap_limit unless gap_limit.nil?
+        response = @client.call_api('receive', method: 'get', data: params)
+        ReceiveResponse.new(JSON.parse(response))
+      end
 
-        class Receive
+      def callback_log(callback, api_key = nil)
+        params = { 'callback' => callback }
+        params['key'] = api_key unless api_key.nil?
+        response = @client.call_api('receive/callback_log', method: 'get', data: params)
+        JSON.parse(response).map { |entry| LogEntry.new(entry) }
+      end
 
-            attr_reader :client
+      def check_gap(xpub, api_key = nil)
+        params = { 'xpub' => xpub }
+        params['key'] = api_key unless api_key.nil?
+        response = @client.call_api('receive/checkgap', method: 'get', data: params)
+        JSON.parse(response)
+      end
 
-            def initialize(base_url = nil)
-                base_url = base_url.nil? ? 'https://api.blockchain.info/v2/' : base_url
-                @client = Client.new(base_url)
-            end
+    end
 
-            def proxy(method_name, *args)
-                warn "[DEPRECATED] avoid use of static methods, use an instance of Receive class instead."
-                send(method_name, *args)
-            end
+    def self.receive(xpub, callback, api_key)
+      Blockchain::V2::Receive.new.proxy(__method__, xpub, callback, api_key)
+    end
 
-            def receive(xpub, callback, api_key, gap_limit = nil)
-                params = { 'xpub' => xpub, 'callback' => callback, 'key' => api_key }
-                if !gap_limit.nil? then params['gap_limit'] = gap_limit end
-                response = @client.call_api('receive', method: 'get', data: params)
-                return ReceiveResponse.new(JSON.parse(response))
-            end
+    def self.callback_log(callback, api_key = nil)
+      Blockchain::V2::Receive.new.proxy(__method__, callback, api_key)
+    end
 
-            def callback_log(callback, api_key = nil)
-                params = {'callback' => callback }
-                params['key'] = api_key unless api_key.nil?
-                response = @client.call_api('receive/callback_log', method: 'get', data: params)
-                json_resp = JSON.parse(response)
-                log_entries = json_resp.map do |entry|
-                    LogEntry.new(JSON.parse(entry))
-                end
-                return log_entries
-            end
+    class ReceiveResponse
+      # @return [String]
+      attr_reader :address
 
-            def check_gap(xpub, api_key = nil)
-                params = {'xpub' => xpub}
-                params['key'] = api_key unless api_key.nil?
-                response = @client.call_api('receive/checkgap', method: 'get', data: params)
-                return JSON.parse(response)
-            end
+      # @return [Integer]
+      attr_reader :index
 
-        end
+      # @return [String]
+      attr_reader :callback_url
 
-		def self.receive(xpub, callback, api_key)
-            Blockchain::V2::Receive.new.proxy(__method__, xpub, callback, api_key)
-		end
+      def initialize(response)
+        @address = response['address']
+        @index = response['index']
+        @callback_url = response['callback']
+      end
+    end
 
-		def self.callback_log(callback, api_key = nil)
-            Blockchain::V2::Receive.new.proxy(__method__, callback, api_key)
-		end
+    class LogEntry
+      # @return [String]
+      attr_reader :callback_url
 
-        class ReceiveResponse
-			attr_reader :address
-			attr_reader :index
-			attr_reader :callback_url
+      # @return [Time]
+      attr_reader :called_at
 
-			def initialize(r)
-				@address = r['address']
-				@index = r['index']
-				@callback_url = r['callback']
-			end
-		end
+      # @return [String]
+      attr_reader :raw_response
 
-		class LogEntry
-			attr_reader :callback_url
-			attr_reader :called_at
-			attr_reader :raw_response
-			attr_reader :response_code
+      # @return [Integer]
+      attr_reader :response_code
 
-			def initialize(r)
-				@callback_url = r['callback_url']
-				@called_at = r['called_at']
-				@raw_response = r['raw_response']
-				@response_code = ['response_code']
-			end
-		end
-	end
-
-
+      def initialize(response)
+        @callback_url = response['callback']
+        @called_at = Time.at(response['calledAt'] / 1000.0)
+        @raw_response = response['rawResponse']
+        @response_code = response['responseCode']
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Fixes `#callback_log`, which attempted to `JSON.parse` a `Hash` (exception) and didn't parse the attributes using the correct keys.
* Removes unused `Blockchain::ReceiveResponse` class.
* Documents attribute types of the response classes.
* Converts a mix of tabs and spaces to spaces.

Surprised to see this quality of code in an official API. Scary to think what kind of code blockchain.info itself runs on.